### PR TITLE
V1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ node_js:
   - "7"
   - "6"
   - "4"
-install: npm i && (cd examples/simple && npm i) && (cd examples/immutable && npm i)
+before_install: npm i -g yarn
+install: yarn
 cache: yarn
 script: "npm run lint && npm run test:cov"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/examples/cancel/.babelrc
+++ b/examples/cancel/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": ["react", "es2015", "stage-0"],
+  "env": {
+    "development": {
+      "presets": ["react-hmre"]
+    }
+  }
+}

--- a/examples/cancel/components/App.js
+++ b/examples/cancel/components/App.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import createLogger from 'redux-logger';
+import { Provider } from 'react-redux';
+import { reducer } from 'react-redux-sweetalert'; // eslint-disable-line
+import 'sweetalert/dist/sweetalert.css';
+
+import Main from './Main';
+
+const rootReducer = combineReducers({
+  sweetalert: reducer,
+});
+
+const logger = createLogger();
+
+const store = createStore(
+  rootReducer,
+  applyMiddleware(thunk, logger),
+);
+
+class App extends Component {
+  render() {
+    return (
+      <Provider store={store}>
+        <Main />
+      </Provider>
+    );
+  }
+}
+
+
+export default App;

--- a/examples/cancel/components/Main.js
+++ b/examples/cancel/components/Main.js
@@ -11,11 +11,13 @@ class Main extends Component {
     return (
       <div>
         <button
-          onClick={() => this.props.swal(
-            'Good job!',
-            'You clicked the button!',
-            'success',
-          )}
+          onClick={() => this.props.swal({
+            title: 'Warning!',
+            text: 'Are you sure?',
+            type: 'info',
+            showCancelButton: true,
+            onCancel: () => console.log('cancel!'),
+          })}
         >Alert</button>
         <ReduxSweetAlert />
       </div>

--- a/examples/cancel/index.html
+++ b/examples/cancel/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>react-redux-sweetalert-example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+	<script src="/static/bundle.js"></script>
+  </body>
+</html>

--- a/examples/cancel/index.js
+++ b/examples/cancel/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import App from './components/App';
+
+render(
+  <App />,
+  document.getElementById('root')
+);

--- a/examples/cancel/package.json
+++ b/examples/cancel/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "react-redux-sweetalert-example",
+  "version": "1.0.0",
+  "description": "react-redux-sweetalert-example-description",
+  "private": true,
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chentsulin/react-redux-sweetalert.git"
+  },
+  "keywords": [
+    "react-redux-sweetalert-keywords"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/chentsulin/react-redux-sweetalert/issues"
+  },
+  "homepage": "https://github.com/chentsulin/react-redux-sweetalert",
+  "dependencies": {
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "react-redux": "^5.0.2",
+    "redux": "^3.6.0",
+    "redux-logger": "^2.7.4",
+    "redux-thunk": "^2.2.0",
+    "sweetalert": "^1.1.3"
+  },
+  "devDependencies": {
+    "babel": "^6.5.2",
+    "babel-cli": "^6.22.2",
+    "babel-core": "^6.22.1",
+    "babel-eslint": "^7.1.1",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-react": "^6.22.0",
+    "babel-preset-react-hmre": "^1.1.1",
+    "babel-preset-stage-0": "^6.22.0",
+    "css-loader": "^0.26.1",
+    "express": "^4.14.1",
+    "style-loader": "^0.13.1",
+    "webpack": "^1.14.0",
+    "webpack-dev-middleware": "^1.9.0",
+    "webpack-hot-middleware": "^2.16.1"
+  }
+}

--- a/examples/cancel/server.js
+++ b/examples/cancel/server.js
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+
+const express = require('express');
+const webpack = require('webpack');
+
+const config = require('./webpack.config');
+
+const port = process.env.PORT || 3000;
+
+const app = express();
+const compiler = webpack(config);
+
+app.use(require('webpack-dev-middleware')(compiler, {
+  publicPath: config.output.publicPath,
+  stats: {
+    colors: true,
+  },
+}));
+
+app.use(require('webpack-hot-middleware')(compiler));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(port, 'localhost', err => {
+  if (err) {
+    console.log(err); // eslint-disable-line no-console
+    return;
+  }
+
+  console.log(`Listening at http://localhost:${port}`); // eslint-disable-line no-console
+});

--- a/examples/cancel/webpack.config.js
+++ b/examples/cancel/webpack.config.js
@@ -1,0 +1,41 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+
+const webpack = require('webpack');
+
+module.exports = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: [
+    'webpack-hot-middleware/client',
+    './index',
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/static/',
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('development'),
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      'react-redux-sweetalert': path.join(__dirname, '..', '..', 'src'),
+    },
+    extensions: ['', '.js'],
+  },
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loaders: ['babel'],
+      exclude: /node_modules/,
+    }, {
+      test: /\.css$/,
+      loaders: ['style-loader', 'css-loader'],
+    }],
+  },
+};

--- a/examples/disable-esc/.babelrc
+++ b/examples/disable-esc/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": ["react", "es2015", "stage-0"],
+  "env": {
+    "development": {
+      "presets": ["react-hmre"]
+    }
+  }
+}

--- a/examples/disable-esc/components/App.js
+++ b/examples/disable-esc/components/App.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import createLogger from 'redux-logger';
+import { Provider } from 'react-redux';
+import { reducer } from 'react-redux-sweetalert'; // eslint-disable-line
+import 'sweetalert/dist/sweetalert.css';
+
+import Main from './Main';
+
+const rootReducer = combineReducers({
+  sweetalert: reducer,
+});
+
+const logger = createLogger();
+
+const store = createStore(
+  rootReducer,
+  applyMiddleware(thunk, logger),
+);
+
+class App extends Component {
+  render() {
+    return (
+      <Provider store={store}>
+        <Main />
+      </Provider>
+    );
+  }
+}
+
+
+export default App;

--- a/examples/disable-esc/components/Main.js
+++ b/examples/disable-esc/components/Main.js
@@ -11,11 +11,13 @@ class Main extends Component {
     return (
       <div>
         <button
-          onClick={() => this.props.swal(
-            'Good job!',
-            'You clicked the button!',
-            'success',
-          )}
+          onClick={() => this.props.swal({
+            title: 'Hi!',
+            text: 'You can\'t close via ESC!',
+            type: 'info',
+            allowEscapeKey: false,
+            onEscapeKey: () => console.log('esc!'),
+          })}
         >Alert</button>
         <ReduxSweetAlert />
       </div>

--- a/examples/disable-esc/index.html
+++ b/examples/disable-esc/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>react-redux-sweetalert-example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+	<script src="/static/bundle.js"></script>
+  </body>
+</html>

--- a/examples/disable-esc/index.js
+++ b/examples/disable-esc/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import App from './components/App';
+
+render(
+  <App />,
+  document.getElementById('root')
+);

--- a/examples/disable-esc/package.json
+++ b/examples/disable-esc/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "react-redux-sweetalert-example",
+  "version": "1.0.0",
+  "description": "react-redux-sweetalert-example-description",
+  "private": true,
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chentsulin/react-redux-sweetalert.git"
+  },
+  "keywords": [
+    "react-redux-sweetalert-keywords"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/chentsulin/react-redux-sweetalert/issues"
+  },
+  "homepage": "https://github.com/chentsulin/react-redux-sweetalert",
+  "dependencies": {
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "react-redux": "^5.0.2",
+    "redux": "^3.6.0",
+    "redux-logger": "^2.7.4",
+    "redux-thunk": "^2.2.0",
+    "sweetalert": "^1.1.3"
+  },
+  "devDependencies": {
+    "babel": "^6.5.2",
+    "babel-cli": "^6.22.2",
+    "babel-core": "^6.22.1",
+    "babel-eslint": "^7.1.1",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-react": "^6.22.0",
+    "babel-preset-react-hmre": "^1.1.1",
+    "babel-preset-stage-0": "^6.22.0",
+    "css-loader": "^0.26.1",
+    "express": "^4.14.1",
+    "style-loader": "^0.13.1",
+    "webpack": "^1.14.0",
+    "webpack-dev-middleware": "^1.9.0",
+    "webpack-hot-middleware": "^2.16.1"
+  }
+}

--- a/examples/disable-esc/server.js
+++ b/examples/disable-esc/server.js
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+
+const express = require('express');
+const webpack = require('webpack');
+
+const config = require('./webpack.config');
+
+const port = process.env.PORT || 3000;
+
+const app = express();
+const compiler = webpack(config);
+
+app.use(require('webpack-dev-middleware')(compiler, {
+  publicPath: config.output.publicPath,
+  stats: {
+    colors: true,
+  },
+}));
+
+app.use(require('webpack-hot-middleware')(compiler));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(port, 'localhost', err => {
+  if (err) {
+    console.log(err); // eslint-disable-line no-console
+    return;
+  }
+
+  console.log(`Listening at http://localhost:${port}`); // eslint-disable-line no-console
+});

--- a/examples/disable-esc/webpack.config.js
+++ b/examples/disable-esc/webpack.config.js
@@ -1,0 +1,41 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+
+const webpack = require('webpack');
+
+module.exports = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: [
+    'webpack-hot-middleware/client',
+    './index',
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/static/',
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('development'),
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      'react-redux-sweetalert': path.join(__dirname, '..', '..', 'src'),
+    },
+    extensions: ['', '.js'],
+  },
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loaders: ['babel'],
+      exclude: /node_modules/,
+    }, {
+      test: /\.css$/,
+      loaders: ['style-loader', 'css-loader'],
+    }],
+  },
+};

--- a/examples/outside-click/.babelrc
+++ b/examples/outside-click/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": ["react", "es2015", "stage-0"],
+  "env": {
+    "development": {
+      "presets": ["react-hmre"]
+    }
+  }
+}

--- a/examples/outside-click/components/App.js
+++ b/examples/outside-click/components/App.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import createLogger from 'redux-logger';
+import { Provider } from 'react-redux';
+import { reducer } from 'react-redux-sweetalert'; // eslint-disable-line
+import 'sweetalert/dist/sweetalert.css';
+
+import Main from './Main';
+
+const rootReducer = combineReducers({
+  sweetalert: reducer,
+});
+
+const logger = createLogger();
+
+const store = createStore(
+  rootReducer,
+  applyMiddleware(thunk, logger),
+);
+
+class App extends Component {
+  render() {
+    return (
+      <Provider store={store}>
+        <Main />
+      </Provider>
+    );
+  }
+}
+
+
+export default App;

--- a/examples/outside-click/components/Main.js
+++ b/examples/outside-click/components/Main.js
@@ -11,11 +11,13 @@ class Main extends Component {
     return (
       <div>
         <button
-          onClick={() => this.props.swal(
-            'Good job!',
-            'You clicked the button!',
-            'success',
-          )}
+          onClick={() => this.props.swal({
+            title: 'Hello!',
+            text: 'Try click outside!',
+            type: 'info',
+            allowOutsideClick: true,
+            onOutsideClick: () => console.log('outside clicked!'),
+          })}
         >Alert</button>
         <ReduxSweetAlert />
       </div>

--- a/examples/outside-click/index.html
+++ b/examples/outside-click/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>react-redux-sweetalert-example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+	<script src="/static/bundle.js"></script>
+  </body>
+</html>

--- a/examples/outside-click/index.js
+++ b/examples/outside-click/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import App from './components/App';
+
+render(
+  <App />,
+  document.getElementById('root')
+);

--- a/examples/outside-click/package.json
+++ b/examples/outside-click/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "react-redux-sweetalert-example",
+  "version": "1.0.0",
+  "description": "react-redux-sweetalert-example-description",
+  "private": true,
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chentsulin/react-redux-sweetalert.git"
+  },
+  "keywords": [
+    "react-redux-sweetalert-keywords"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/chentsulin/react-redux-sweetalert/issues"
+  },
+  "homepage": "https://github.com/chentsulin/react-redux-sweetalert",
+  "dependencies": {
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "react-redux": "^5.0.2",
+    "redux": "^3.6.0",
+    "redux-logger": "^2.7.4",
+    "redux-thunk": "^2.2.0",
+    "sweetalert": "^1.1.3"
+  },
+  "devDependencies": {
+    "babel": "^6.5.2",
+    "babel-cli": "^6.22.2",
+    "babel-core": "^6.22.1",
+    "babel-eslint": "^7.1.1",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-react": "^6.22.0",
+    "babel-preset-react-hmre": "^1.1.1",
+    "babel-preset-stage-0": "^6.22.0",
+    "css-loader": "^0.26.1",
+    "express": "^4.14.1",
+    "style-loader": "^0.13.1",
+    "webpack": "^1.14.0",
+    "webpack-dev-middleware": "^1.9.0",
+    "webpack-hot-middleware": "^2.16.1"
+  }
+}

--- a/examples/outside-click/server.js
+++ b/examples/outside-click/server.js
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+
+const express = require('express');
+const webpack = require('webpack');
+
+const config = require('./webpack.config');
+
+const port = process.env.PORT || 3000;
+
+const app = express();
+const compiler = webpack(config);
+
+app.use(require('webpack-dev-middleware')(compiler, {
+  publicPath: config.output.publicPath,
+  stats: {
+    colors: true,
+  },
+}));
+
+app.use(require('webpack-hot-middleware')(compiler));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(port, 'localhost', err => {
+  if (err) {
+    console.log(err); // eslint-disable-line no-console
+    return;
+  }
+
+  console.log(`Listening at http://localhost:${port}`); // eslint-disable-line no-console
+});

--- a/examples/outside-click/webpack.config.js
+++ b/examples/outside-click/webpack.config.js
@@ -1,0 +1,41 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+
+const webpack = require('webpack');
+
+module.exports = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: [
+    'webpack-hot-middleware/client',
+    './index',
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/static/',
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('development'),
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      'react-redux-sweetalert': path.join(__dirname, '..', '..', 'src'),
+    },
+    extensions: ['', '.js'],
+  },
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loaders: ['babel'],
+      exclude: /node_modules/,
+    }, {
+      test: /\.css$/,
+      loaders: ['style-loader', 'css-loader'],
+    }],
+  },
+};

--- a/examples/simple/components/Main.js
+++ b/examples/simple/components/Main.js
@@ -1,22 +1,21 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import ReduxSweetAlert, { showAlert, dismissAlert } from 'react-redux-sweetalert'; // eslint-disable-line
+import ReduxSweetAlert, { swal } from 'react-redux-sweetalert'; // eslint-disable-line
 
 
 class Main extends Component {
   static propTypes = {
-    dismissAlert: PropTypes.func.isRequired,
-    showAlert: PropTypes.func.isRequired,
+    swal: PropTypes.func.isRequired,
   };
   render() {
     return (
       <div>
         <button
-          onClick={() => this.props.showAlert({
-            title: 'Demo',
-            text: 'SweetAlert in React',
-            onConfirm: this.props.dismissAlert,
-          })}
+          onClick={() => this.props.swal(
+            'Good job!',
+            'You clicked the button!',
+            'success',
+          )}
         >Alert</button>
         <ReduxSweetAlert />
       </div>
@@ -26,6 +25,5 @@ class Main extends Component {
 
 
 export default connect(null, {
-  showAlert,
-  dismissAlert,
+  swal,
 })(Main);

--- a/examples/timer/.babelrc
+++ b/examples/timer/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": ["react", "es2015", "stage-0"],
+  "env": {
+    "development": {
+      "presets": ["react-hmre"]
+    }
+  }
+}

--- a/examples/timer/components/App.js
+++ b/examples/timer/components/App.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import createLogger from 'redux-logger';
+import { Provider } from 'react-redux';
+import { reducer } from 'react-redux-sweetalert'; // eslint-disable-line
+import 'sweetalert/dist/sweetalert.css';
+
+import Main from './Main';
+
+const rootReducer = combineReducers({
+  sweetalert: reducer,
+});
+
+const logger = createLogger();
+
+const store = createStore(
+  rootReducer,
+  applyMiddleware(thunk, logger),
+);
+
+class App extends Component {
+  render() {
+    return (
+      <Provider store={store}>
+        <Main />
+      </Provider>
+    );
+  }
+}
+
+
+export default App;

--- a/examples/timer/components/Main.js
+++ b/examples/timer/components/Main.js
@@ -11,11 +11,13 @@ class Main extends Component {
     return (
       <div>
         <button
-          onClick={() => this.props.swal(
-            'Good job!',
-            'You clicked the button!',
-            'success',
-          )}
+          onClick={() => this.props.swal({
+            title: 'Sorry!',
+            text: 'Close after 3 seconds!',
+            type: 'error',
+            timer: 3000,
+            onClose: () => console.log('closed!'),
+          })}
         >Alert</button>
         <ReduxSweetAlert />
       </div>

--- a/examples/timer/index.html
+++ b/examples/timer/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>react-redux-sweetalert-example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+	<script src="/static/bundle.js"></script>
+  </body>
+</html>

--- a/examples/timer/index.js
+++ b/examples/timer/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import App from './components/App';
+
+render(
+  <App />,
+  document.getElementById('root')
+);

--- a/examples/timer/package.json
+++ b/examples/timer/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "react-redux-sweetalert-example",
+  "version": "1.0.0",
+  "description": "react-redux-sweetalert-example-description",
+  "private": true,
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chentsulin/react-redux-sweetalert.git"
+  },
+  "keywords": [
+    "react-redux-sweetalert-keywords"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/chentsulin/react-redux-sweetalert/issues"
+  },
+  "homepage": "https://github.com/chentsulin/react-redux-sweetalert",
+  "dependencies": {
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "react-redux": "^5.0.2",
+    "redux": "^3.6.0",
+    "redux-logger": "^2.7.4",
+    "redux-thunk": "^2.2.0",
+    "sweetalert": "^1.1.3"
+  },
+  "devDependencies": {
+    "babel": "^6.5.2",
+    "babel-cli": "^6.22.2",
+    "babel-core": "^6.22.1",
+    "babel-eslint": "^7.1.1",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-react": "^6.22.0",
+    "babel-preset-react-hmre": "^1.1.1",
+    "babel-preset-stage-0": "^6.22.0",
+    "css-loader": "^0.26.1",
+    "express": "^4.14.1",
+    "style-loader": "^0.13.1",
+    "webpack": "^1.14.0",
+    "webpack-dev-middleware": "^1.9.0",
+    "webpack-hot-middleware": "^2.16.1"
+  }
+}

--- a/examples/timer/server.js
+++ b/examples/timer/server.js
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+
+const express = require('express');
+const webpack = require('webpack');
+
+const config = require('./webpack.config');
+
+const port = process.env.PORT || 3000;
+
+const app = express();
+const compiler = webpack(config);
+
+app.use(require('webpack-dev-middleware')(compiler, {
+  publicPath: config.output.publicPath,
+  stats: {
+    colors: true,
+  },
+}));
+
+app.use(require('webpack-hot-middleware')(compiler));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(port, 'localhost', err => {
+  if (err) {
+    console.log(err); // eslint-disable-line no-console
+    return;
+  }
+
+  console.log(`Listening at http://localhost:${port}`); // eslint-disable-line no-console
+});

--- a/examples/timer/webpack.config.js
+++ b/examples/timer/webpack.config.js
@@ -1,0 +1,41 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+
+const webpack = require('webpack');
+
+module.exports = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: [
+    'webpack-hot-middleware/client',
+    './index',
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/static/',
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('development'),
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      'react-redux-sweetalert': path.join(__dirname, '..', '..', 'src'),
+    },
+    extensions: ['', '.js'],
+  },
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loaders: ['babel'],
+      exclude: /node_modules/,
+    }, {
+      test: /\.css$/,
+      loaders: ['style-loader', 'css-loader'],
+    }],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     ]
   },
   "dependencies": {
+    "compose-function": "^3.0.3",
     "react-redux": "^5.0.2",
     "sweetalert-react": "^0.4.7",
     "warning": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "chentsulin/react-redux-sweetalert",
   "scripts": {
     "clean": "rimraf lib dist coverage",
-    "lint": "eslint src test examples",
+    "lint": "eslint src test",
     "test": "jest",
     "test:watch": "npm test -- --watch",
     "test:cov": "npm test -- --coverage",

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -28,6 +28,43 @@ describe('sweetalert', () => {
     expect(console.error).not.toBeCalled();
   });
 
+  it('should assign title directly', () => {
+    const dispatch = jest.fn();
+    sweetalert('Good job!')(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    expect(action.type).toBe(SHOW);
+    expect(action.payload.title).toBe('Good job!');
+    expect(console.error).not.toBeCalled();
+  });
+
+  it('should assign title, text directly', () => {
+    const dispatch = jest.fn();
+    sweetalert(
+      'Good job!',
+      'You clicked the button!',
+    )(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    expect(action.type).toBe(SHOW);
+    expect(action.payload.title).toBe('Good job!');
+    expect(action.payload.text).toBe('You clicked the button!');
+    expect(console.error).not.toBeCalled();
+  });
+
+  it('should assign title, text, type directly', () => {
+    const dispatch = jest.fn();
+    sweetalert(
+      'Good job!',
+      'You clicked the button!',
+      'success',
+    )(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    expect(action.type).toBe(SHOW);
+    expect(action.payload.title).toBe('Good job!');
+    expect(action.payload.text).toBe('You clicked the button!');
+    expect(action.payload.type).toBe('success');
+    expect(console.error).not.toBeCalled();
+  });
+
   it('should allow custom option in payload', () => {
     const dispatch = jest.fn();
     const payload = {

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -9,7 +9,13 @@ import {
 
 beforeEach(() => {
   console.error = jest.fn();
+  jest.useFakeTimers();
 });
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 
 describe('sweetalert', () => {
   it('should create SHOW action without error', () => {
@@ -130,6 +136,29 @@ describe('sweetalert', () => {
     expect(dispatch.mock.calls[1][0]).toEqual({
       type: DISMISS,
     });
+  });
+
+  it('should dispatch dismiss when timer set', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+      timer: 1000,
+    };
+    sweetalert(payload)(dispatch);
+    jest.runTimersToTime(1100);
+    expect(dispatch.mock.calls[1][0]).toEqual({
+      type: DISMISS,
+    });
+  });
+
+  it('should not dispatch dismiss when no timer option', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+    };
+    sweetalert(payload)(dispatch);
+    jest.runAllTimers();
+    expect(dispatch).toHaveBeenCalledTimes(1);
   });
 
   it('should warn for invalid props', () => {

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -1,10 +1,8 @@
 /* eslint-disable no-console */
 import {
   SHOW,
-  REPLACE,
   DISMISS,
   sweetalert,
-  replace,
   dismiss,
 } from '../actions';
 
@@ -40,25 +38,6 @@ describe('sweetalert', () => {
     );
   });
 });
-
-describe('replace', () => {
-  it('should create REPLACE action', () => {
-    const payload = { title: 'replace' };
-    expect(replace(payload)).toEqual({
-      type: REPLACE,
-      payload: { title: 'replace' },
-    });
-  });
-
-  it('should warn for invalid props', () => {
-    const payload = { titl: 'replace' };
-    replace(payload);
-    expect(console.error).toBeCalledWith(
-      'Warning: Property titl is invalid. You can not pass it to SweetAlert',
-    );
-  });
-});
-
 
 describe('dismiss', () => {
   it('should create DISMISS action', () => {

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -12,27 +12,130 @@ beforeEach(() => {
 });
 
 describe('sweetalert', () => {
-  it('should create SHOW action', () => {
+  it('should create SHOW action without error', () => {
+    const dispatch = jest.fn();
     const payload = { title: 'show' };
-    expect(sweetalert(payload)).toEqual({
-      type: SHOW,
-      payload: { title: 'show' },
-    });
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    expect(action.type).toBe(SHOW);
+    expect(action.payload.title).toBe('show');
     expect(console.error).not.toBeCalled();
   });
 
   it('should allow custom option in payload', () => {
+    const dispatch = jest.fn();
     const payload = {
       title: 'show',
       onCancel: () => {},
     };
-    sweetalert(payload);
+    sweetalert(payload)(dispatch);
     expect(console.error).not.toBeCalled();
   });
 
+  it('should close on confirm as default', () => {
+    const dispatch = jest.fn();
+    const payload = { title: 'show' };
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    action.payload.onConfirm();
+    expect(dispatch.mock.calls[1][0]).toEqual({
+      type: DISMISS,
+    });
+  });
+
+  it('should not dispatch dismiss when closeOnConfirm: false', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+      closeOnConfirm: false,
+    };
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    action.payload.onConfirm();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close on cancel as default', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+      showCancelButton: true,
+    };
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    action.payload.onCancel();
+    expect(dispatch.mock.calls[1][0]).toEqual({
+      type: DISMISS,
+    });
+  });
+
+  it('should not dispatch dismiss when closeOnCancel: false', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+      showCancelButton: true,
+      closeOnCancel: false,
+    };
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    action.payload.onCancel();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should allow escape key as default', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+    };
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    action.payload.onEscapeKey();
+    expect(dispatch.mock.calls[1][0]).toEqual({
+      type: DISMISS,
+    });
+  });
+
+  it('should not dispatch dismiss when allowEscapeKey: false', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+      allowEscapeKey: false,
+    };
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    action.payload.onEscapeKey();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not allow outside click as default', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+    };
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    action.payload.onOutsideClick();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not dispatch dismiss when allowOutsideClick: true', () => {
+    const dispatch = jest.fn();
+    const payload = {
+      title: 'show',
+      allowOutsideClick: true,
+    };
+    sweetalert(payload)(dispatch);
+    const action = dispatch.mock.calls[0][0];
+    action.payload.onOutsideClick();
+    expect(dispatch.mock.calls[1][0]).toEqual({
+      type: DISMISS,
+    });
+  });
+
   it('should warn for invalid props', () => {
+    const dispatch = jest.fn();
     const payload = { titl: 'show' };
-    sweetalert(payload);
+    sweetalert(payload)(dispatch);
     expect(console.error).toBeCalledWith(
       'Warning: Property titl is invalid. You can not pass it to SweetAlert',
     );

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -3,9 +3,9 @@ import {
   SHOW,
   REPLACE,
   DISMISS,
-  showAlert,
-  replaceAlert,
-  dismissAlert,
+  sweetalert,
+  replace,
+  dismiss,
 } from '../actions';
 
 
@@ -13,10 +13,10 @@ beforeEach(() => {
   console.error = jest.fn();
 });
 
-describe('showAlert', () => {
+describe('sweetalert', () => {
   it('should create SHOW action', () => {
     const payload = { title: 'show' };
-    expect(showAlert(payload)).toEqual({
+    expect(sweetalert(payload)).toEqual({
       type: SHOW,
       payload: { title: 'show' },
     });
@@ -28,23 +28,23 @@ describe('showAlert', () => {
       title: 'show',
       onCancel: () => {},
     };
-    showAlert(payload);
+    sweetalert(payload);
     expect(console.error).not.toBeCalled();
   });
 
   it('should warn for invalid props', () => {
     const payload = { titl: 'show' };
-    showAlert(payload);
+    sweetalert(payload);
     expect(console.error).toBeCalledWith(
       'Warning: Property titl is invalid. You can not pass it to SweetAlert',
     );
   });
 });
 
-describe('replaceAlert', () => {
+describe('replace', () => {
   it('should create REPLACE action', () => {
     const payload = { title: 'replace' };
-    expect(replaceAlert(payload)).toEqual({
+    expect(replace(payload)).toEqual({
       type: REPLACE,
       payload: { title: 'replace' },
     });
@@ -52,7 +52,7 @@ describe('replaceAlert', () => {
 
   it('should warn for invalid props', () => {
     const payload = { titl: 'replace' };
-    replaceAlert(payload);
+    replace(payload);
     expect(console.error).toBeCalledWith(
       'Warning: Property titl is invalid. You can not pass it to SweetAlert',
     );
@@ -60,9 +60,9 @@ describe('replaceAlert', () => {
 });
 
 
-describe('dismissAlert', () => {
+describe('dismiss', () => {
   it('should create DISMISS action', () => {
-    expect(dismissAlert()).toEqual({
+    expect(dismiss()).toEqual({
       type: DISMISS,
     });
   });

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 import {
   SHOW,
-  DISMISS,
+  CLOSE,
   sweetalert,
-  dismiss,
+  close,
 } from '../actions';
 
 
@@ -82,11 +82,11 @@ describe('sweetalert', () => {
     const action = dispatch.mock.calls[0][0];
     action.payload.onConfirm();
     expect(dispatch.mock.calls[1][0]).toEqual({
-      type: DISMISS,
+      type: CLOSE,
     });
   });
 
-  it('should not dispatch dismiss when closeOnConfirm: false', () => {
+  it('should not dispatch close when closeOnConfirm: false', () => {
     const dispatch = jest.fn();
     const payload = {
       title: 'show',
@@ -108,11 +108,11 @@ describe('sweetalert', () => {
     const action = dispatch.mock.calls[0][0];
     action.payload.onCancel();
     expect(dispatch.mock.calls[1][0]).toEqual({
-      type: DISMISS,
+      type: CLOSE,
     });
   });
 
-  it('should not dispatch dismiss when closeOnCancel: false', () => {
+  it('should not dispatch close when closeOnCancel: false', () => {
     const dispatch = jest.fn();
     const payload = {
       title: 'show',
@@ -134,11 +134,11 @@ describe('sweetalert', () => {
     const action = dispatch.mock.calls[0][0];
     action.payload.onEscapeKey();
     expect(dispatch.mock.calls[1][0]).toEqual({
-      type: DISMISS,
+      type: CLOSE,
     });
   });
 
-  it('should not dispatch dismiss when allowEscapeKey: false', () => {
+  it('should not dispatch close when allowEscapeKey: false', () => {
     const dispatch = jest.fn();
     const payload = {
       title: 'show',
@@ -161,7 +161,7 @@ describe('sweetalert', () => {
     expect(dispatch).toHaveBeenCalledTimes(1);
   });
 
-  it('should not dispatch dismiss when allowOutsideClick: true', () => {
+  it('should not dispatch close when allowOutsideClick: true', () => {
     const dispatch = jest.fn();
     const payload = {
       title: 'show',
@@ -171,11 +171,11 @@ describe('sweetalert', () => {
     const action = dispatch.mock.calls[0][0];
     action.payload.onOutsideClick();
     expect(dispatch.mock.calls[1][0]).toEqual({
-      type: DISMISS,
+      type: CLOSE,
     });
   });
 
-  it('should dispatch dismiss when timer set', () => {
+  it('should dispatch close when timer set', () => {
     const dispatch = jest.fn();
     const payload = {
       title: 'show',
@@ -184,11 +184,11 @@ describe('sweetalert', () => {
     sweetalert(payload)(dispatch);
     jest.runTimersToTime(1100);
     expect(dispatch.mock.calls[1][0]).toEqual({
-      type: DISMISS,
+      type: CLOSE,
     });
   });
 
-  it('should not dispatch dismiss when no timer option', () => {
+  it('should not dispatch close when no timer option', () => {
     const dispatch = jest.fn();
     const payload = {
       title: 'show',
@@ -208,10 +208,10 @@ describe('sweetalert', () => {
   });
 });
 
-describe('dismiss', () => {
-  it('should create DISMISS action', () => {
-    expect(dismiss()).toEqual({
-      type: DISMISS,
+describe('close', () => {
+  it('should create CLOSE action', () => {
+    expect(close()).toEqual({
+      type: CLOSE,
     });
   });
 });

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -2,6 +2,7 @@ import ReduxSweetAlert, {
   sweetalert,
   swal,
   close,
+  closeIfShow,
   reducer,
   immutableReducer,
   actions,
@@ -19,5 +20,6 @@ it('should export correctly', () => {
     sweetalert,
     swal,
     close,
+    closeIfShow,
   });
 });

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,17 +1,26 @@
 import ReduxSweetAlert, {
-  showAlert,
-  replaceAlert,
-  dismissAlert,
+  sweetalert,
+  swal,
+  replace,
+  dismiss,
   reducer,
   immutableReducer,
+  actions,
 } from '../';
 
 
 it('should export correctly', () => {
   expect(ReduxSweetAlert).toBeDefined();
-  expect(showAlert).toBeDefined();
-  expect(replaceAlert).toBeDefined();
-  expect(dismissAlert).toBeDefined();
+  expect(sweetalert).toBeDefined();
+  expect(swal).toBeDefined();
+  expect(replace).toBeDefined();
+  expect(dismiss).toBeDefined();
   expect(reducer).toBeDefined();
   expect(immutableReducer).toBeDefined();
+  expect(actions).toEqual({
+    sweetalert,
+    swal,
+    replace,
+    dismiss,
+  });
 });

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,7 +1,7 @@
 import ReduxSweetAlert, {
   sweetalert,
   swal,
-  dismiss,
+  close,
   reducer,
   immutableReducer,
   actions,
@@ -12,12 +12,12 @@ it('should export correctly', () => {
   expect(ReduxSweetAlert).toBeDefined();
   expect(sweetalert).toBeDefined();
   expect(swal).toBeDefined();
-  expect(dismiss).toBeDefined();
+  expect(close).toBeDefined();
   expect(reducer).toBeDefined();
   expect(immutableReducer).toBeDefined();
   expect(actions).toEqual({
     sweetalert,
     swal,
-    dismiss,
+    close,
   });
 });

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,7 +1,6 @@
 import ReduxSweetAlert, {
   sweetalert,
   swal,
-  replace,
   dismiss,
   reducer,
   immutableReducer,
@@ -13,14 +12,12 @@ it('should export correctly', () => {
   expect(ReduxSweetAlert).toBeDefined();
   expect(sweetalert).toBeDefined();
   expect(swal).toBeDefined();
-  expect(replace).toBeDefined();
   expect(dismiss).toBeDefined();
   expect(reducer).toBeDefined();
   expect(immutableReducer).toBeDefined();
   expect(actions).toEqual({
     sweetalert,
     swal,
-    replace,
     dismiss,
   });
 });

--- a/src/__tests__/reducer-immutable.spec.js
+++ b/src/__tests__/reducer-immutable.spec.js
@@ -3,8 +3,7 @@ import { fromJS } from 'immutable';
 
 import {
   SHOW,
-  REPLACE,
-  DISMISS,
+  CLOSE,
 } from '../actions';
 
 beforeEach(() => {
@@ -29,16 +28,16 @@ it('should handle SHOW action', () => {
   });
 });
 
-it('should handle DISMISS action', () => {
+it('should handle CLOSE action', () => {
   const immutableReducer = require('../reducer-immutable').default;
   const prevState = fromJS({
     show: true,
     title: 'replace',
   });
-  const dismissAction = {
-    type: DISMISS,
+  const closeAction = {
+    type: CLOSE,
   };
-  expect(immutableReducer(prevState, dismissAction).toJS()).toEqual({
+  expect(immutableReducer(prevState, closeAction).toJS()).toEqual({
     show: false,
     title: '',
   });

--- a/src/__tests__/reducer-immutable.spec.js
+++ b/src/__tests__/reducer-immutable.spec.js
@@ -29,24 +29,6 @@ it('should handle SHOW action', () => {
   });
 });
 
-it('should handle REPLACE action', () => {
-  const immutableReducer = require('../reducer-immutable').default;
-  const prevState = fromJS({
-    show: true,
-    title: 'show',
-  });
-  const replaceAction = {
-    type: REPLACE,
-    payload: {
-      title: 'replace',
-    },
-  };
-  expect(immutableReducer(prevState, replaceAction).toJS()).toEqual({
-    show: true,
-    title: 'replace',
-  });
-});
-
 it('should handle DISMISS action', () => {
   const immutableReducer = require('../reducer-immutable').default;
   const prevState = fromJS({

--- a/src/__tests__/reducer.spec.js
+++ b/src/__tests__/reducer.spec.js
@@ -1,7 +1,6 @@
 import {
   SHOW,
-  REPLACE,
-  DISMISS,
+  CLOSE,
 } from '../actions';
 import reducer from '../reducer';
 
@@ -23,15 +22,15 @@ it('should handle SHOW action', () => {
   });
 });
 
-it('should handle DISMISS action', () => {
+it('should handle CLOSE action', () => {
   const prevState = {
     show: true,
     title: 'replace',
   };
-  const dismissAction = {
-    type: DISMISS,
+  const closeAction = {
+    type: CLOSE,
   };
-  expect(reducer(prevState, dismissAction)).toEqual({
+  expect(reducer(prevState, closeAction)).toEqual({
     show: false,
     title: '',
   });

--- a/src/__tests__/reducer.spec.js
+++ b/src/__tests__/reducer.spec.js
@@ -23,23 +23,6 @@ it('should handle SHOW action', () => {
   });
 });
 
-it('should handle REPLACE action', () => {
-  const prevState = {
-    show: true,
-    title: 'show',
-  };
-  const replaceAction = {
-    type: REPLACE,
-    payload: {
-      title: 'replace',
-    },
-  };
-  expect(reducer(prevState, replaceAction)).toEqual({
-    show: true,
-    title: 'replace',
-  });
-});
-
 it('should handle DISMISS action', () => {
   const prevState = {
     show: true,

--- a/src/actions.js
+++ b/src/actions.js
@@ -52,6 +52,20 @@ export const close = () => {
   });
 };
 
+export const closeIfShow = () => {
+  if (_timeout) {
+    clearTimeout(_timeout);
+    _timeout = null;
+  }
+  return (dispatch, getState) => {
+    if (getState().sweetalert.show) {
+      dispatch({
+        type: CLOSE,
+      });
+    }
+  };
+};
+
 
 function getInvalidProps(payload) {
   return Object.keys(payload).filter(key => ALLOWS_KEYS.indexOf(key) === -1);

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,6 @@
 import warning from 'warning';
 
 export const SHOW = '@sweetalert/SHOW';
-export const REPLACE = '@sweetalert/REPLACE';
 export const DISMISS = '@sweetalert/DISMISS';
 
 
@@ -48,13 +47,6 @@ export const sweetalert = payload => {
   warningInvalidProps(payload);
   return {
     type: SHOW,
-    payload,
-  };
-};
-export const replace = payload => {
-  warningInvalidProps(payload);
-  return {
-    type: REPLACE,
     payload,
   };
 };

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,7 +2,7 @@ import warning from 'warning';
 import compose from 'compose-function';
 
 export const SHOW = '@sweetalert/SHOW';
-export const DISMISS = '@sweetalert/DISMISS';
+export const CLOSE = '@sweetalert/CLOSE';
 
 
 const ALLOWS_KEYS = [
@@ -42,13 +42,13 @@ const ALLOWS_KEYS = [
 
 let _timeout;
 
-export const dismiss = () => {
+export const close = () => {
   if (_timeout) {
     clearTimeout(_timeout);
     _timeout = null;
   }
   return ({
-    type: DISMISS,
+    type: CLOSE,
   });
 };
 
@@ -83,7 +83,7 @@ function createCloseOnConfirmTransform(dispatch) {
     onConfirm: (...args) => {
       if (typeof payload.onConfirm === 'function') payload.onConfirm(...args);
       if (closeOnConfirm !== false) {
-        dispatch(dismiss());
+        dispatch(close());
       }
     },
   });
@@ -95,7 +95,7 @@ function createCloseOnCancelTransform(dispatch) {
     onCancel: (...args) => {
       if (typeof payload.onCancel === 'function') payload.onCancel(...args);
       if (closeOnCancel !== false) {
-        dispatch(dismiss());
+        dispatch(close());
       }
     },
   });
@@ -107,7 +107,7 @@ function createAllowEscapeKeyTransform(dispatch) {
     onEscapeKey: (...args) => {
       if (typeof payload.onEscapeKey === 'function') payload.onEscapeKey(...args);
       if (allowEscapeKey !== false) {
-        dispatch(dismiss());
+        dispatch(close());
       }
     },
   });
@@ -119,7 +119,7 @@ function createAllowOutsideClickTransform(dispatch) {
     onOutsideClick: (...args) => {
       if (typeof payload.onOutsideClick === 'function') payload.onOutsideClick(...args);
       if (allowOutsideClick === true) {
-        dispatch(dismiss());
+        dispatch(close());
       }
     },
   });
@@ -128,7 +128,7 @@ function createAllowOutsideClickTransform(dispatch) {
 function createTimerTransform(dispatch) {
   return ({ timer, ...payload }) => {
     if (timer && typeof timer === 'number') {
-      _timeout = setTimeout(() => dispatch(dismiss()), timer);
+      _timeout = setTimeout(() => dispatch(close()), timer);
     }
     return payload;
   };

--- a/src/actions.js
+++ b/src/actions.js
@@ -44,20 +44,20 @@ function warningInvalidProps(payload) {
   });
 }
 
-export const showAlert = payload => {
+export const sweetalert = payload => {
   warningInvalidProps(payload);
   return {
     type: SHOW,
     payload,
   };
 };
-export const replaceAlert = payload => {
+export const replace = payload => {
   warningInvalidProps(payload);
   return {
     type: REPLACE,
     payload,
   };
 };
-export const dismissAlert = () => ({
+export const dismiss = () => ({
   type: DISMISS,
 });

--- a/src/actions.js
+++ b/src/actions.js
@@ -64,6 +64,18 @@ function warningInvalidProps(payload) {
   });
 }
 
+function parseArgument(f1, f2, f3) {
+  if (typeof f1 === 'string') {
+    const payload = {
+      title: f1,
+    };
+    if (f2) payload.text = f2;
+    if (f3) payload.type = f3;
+    return payload;
+  }
+  return f1;
+}
+
 
 function createCloseOnConfirmTransform(dispatch) {
   return ({ closeOnConfirm, ...payload }) => ({
@@ -123,7 +135,8 @@ function createTimerTransform(dispatch) {
 }
 
 
-export const sweetalert = payload => {
+export const sweetalert = (...args) => {
+  const payload = parseArgument(...args);
   warningInvalidProps(payload);
   return dispatch => {
     const closeOnConfirm = createCloseOnConfirmTransform(dispatch);

--- a/src/actions.js
+++ b/src/actions.js
@@ -27,6 +27,9 @@ const ALLOWS_KEYS = [
 
   'closeOnConfirm',
   'closeOnCancel',
+  'allowEscapeKey',
+  'allowOutsideClick',
+  'timer',
 
   // custom option
   'onConfirm',
@@ -36,9 +39,18 @@ const ALLOWS_KEYS = [
   'onOutsideClick',
 ];
 
-export const dismiss = () => ({
-  type: DISMISS,
-});
+
+let _timeout;
+
+export const dismiss = () => {
+  if (_timeout) {
+    clearTimeout(_timeout);
+    _timeout = null;
+  }
+  return ({
+    type: DISMISS,
+  });
+};
 
 
 function getInvalidProps(payload) {
@@ -101,6 +113,15 @@ function createAllowOutsideClickTransform(dispatch) {
   });
 }
 
+function createTimerTransform(dispatch) {
+  return ({ timer, ...payload }) => {
+    if (timer && typeof timer === 'number') {
+      _timeout = setTimeout(() => dispatch(dismiss()), timer);
+    }
+    return payload;
+  };
+}
+
 
 export const sweetalert = payload => {
   warningInvalidProps(payload);
@@ -109,12 +130,14 @@ export const sweetalert = payload => {
     const closeOnCancel = createCloseOnCancelTransform(dispatch);
     const allowEscapeKey = createAllowEscapeKeyTransform(dispatch);
     const allowOutsideClick = createAllowOutsideClickTransform(dispatch);
+    const timer = createTimerTransform(dispatch);
 
     const transform = compose(
       closeOnConfirm,
       closeOnCancel,
       allowEscapeKey,
       allowOutsideClick,
+      timer,
     );
 
     dispatch({

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import ReduxSweetAlert from './ReduxSweetAlert';
 import {
   sweetalert,
-  replace,
   dismiss,
 } from './actions';
 
@@ -11,7 +10,6 @@ export { default as immutableReducer } from './reducer-immutable';
 
 export {
   sweetalert,
-  replace,
   dismiss,
 };
 
@@ -20,6 +18,5 @@ export const swal = sweetalert;
 export const actions = {
   sweetalert,
   swal,
-  replace,
   dismiss,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import ReduxSweetAlert from './ReduxSweetAlert';
 import {
   sweetalert,
   close,
+  closeIfShow,
 } from './actions';
 
 export default ReduxSweetAlert;
@@ -11,6 +12,7 @@ export { default as immutableReducer } from './reducer-immutable';
 export {
   sweetalert,
   close,
+  closeIfShow,
 };
 
 export const swal = sweetalert;
@@ -19,4 +21,5 @@ export const actions = {
   sweetalert,
   swal,
   close,
+  closeIfShow,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import ReduxSweetAlert from './ReduxSweetAlert';
 import {
   sweetalert,
-  dismiss,
+  close,
 } from './actions';
 
 export default ReduxSweetAlert;
@@ -10,7 +10,7 @@ export { default as immutableReducer } from './reducer-immutable';
 
 export {
   sweetalert,
-  dismiss,
+  close,
 };
 
 export const swal = sweetalert;
@@ -18,5 +18,5 @@ export const swal = sweetalert;
 export const actions = {
   sweetalert,
   swal,
-  dismiss,
+  close,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,25 @@
 import ReduxSweetAlert from './ReduxSweetAlert';
+import {
+  sweetalert,
+  replace,
+  dismiss,
+} from './actions';
 
 export default ReduxSweetAlert;
 export { default as reducer } from './reducer';
 export { default as immutableReducer } from './reducer-immutable';
-export {
-  showAlert,
-  replaceAlert,
-  dismissAlert,
-} from './actions';
 
+export {
+  sweetalert,
+  replace,
+  dismiss,
+};
+
+export const swal = sweetalert;
+
+export const actions = {
+  sweetalert,
+  swal,
+  replace,
+  dismiss,
+};

--- a/src/reducer-immutable.js
+++ b/src/reducer-immutable.js
@@ -4,7 +4,6 @@ import warning from 'warning';
 import createReducer from './utils/createReducer';
 import {
   SHOW,
-  REPLACE,
   DISMISS,
 } from './actions';
 
@@ -23,8 +22,6 @@ try {
       show: true,
       ...payload,
     }),
-
-    [REPLACE]: (state, { payload }) => state.mergeDeep(payload),
 
     [DISMISS]: () => initialState,
   });

--- a/src/reducer-immutable.js
+++ b/src/reducer-immutable.js
@@ -4,7 +4,7 @@ import warning from 'warning';
 import createReducer from './utils/createReducer';
 import {
   SHOW,
-  DISMISS,
+  CLOSE,
 } from './actions';
 
 let reducer; // eslint-disable-line import/no-mutable-exports
@@ -23,7 +23,7 @@ try {
       ...payload,
     }),
 
-    [DISMISS]: () => initialState,
+    [CLOSE]: () => initialState,
   });
 } catch (error) {
   reducer = () => {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,7 +1,6 @@
 import createReducer from './utils/createReducer';
 import {
   SHOW,
-  REPLACE,
   DISMISS,
 } from './actions';
 
@@ -15,11 +14,6 @@ const initialState = {
 export default createReducer(initialState, {
   [SHOW]: (state, { payload }) => ({
     show: true,
-    ...payload,
-  }),
-
-  [REPLACE]: (state, { payload }) => ({
-    ...state,
     ...payload,
   }),
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,7 +1,7 @@
 import createReducer from './utils/createReducer';
 import {
   SHOW,
-  DISMISS,
+  CLOSE,
 } from './actions';
 
 
@@ -17,5 +17,5 @@ export default createReducer(initialState, {
     ...payload,
   }),
 
-  [DISMISS]: () => initialState,
+  [CLOSE]: () => initialState,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,6 +103,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arity-n@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -1167,6 +1171,12 @@ commander@^2.8.1, commander@^2.9.0:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+compose-function@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/compose-function/-/compose-function-3.0.3.tgz#9ed675f13cc54501d30950a486ff6a7ba3ab185f"
+  dependencies:
+    arity-n "^1.0.4"
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
- Renamed `showAlert` to `sweetalert`, `swal`
- Removed `replaceAlert`
- Renamed `dismissAlert` to `close`
- supported `showConfirmButton`
- supported `showCancelButton`
- supported `allowEscapeKey`
- supported `allowOutsideClick`
- supported `timer`
- supported shortcut:
```js
sweetalert("Oops...", "Something went wrong!", "error");
```

Todo:

- sweetalert? sweetAlert? - a little bit confusing